### PR TITLE
DTSW-7039-change-port-11511-for-dtps-to-11911-in-dt-device-proxy

### DIFF
--- a/assets/proxy.conf
+++ b/assets/proxy.conf
@@ -31,7 +31,7 @@ server {
   #
 
   location /dtps/ {
-    proxy_pass  http://127.0.0.1:11511/;
+    proxy_pass  http://127.0.0.1:11911/;
     proxy_set_header Host $http_host;
   }
 


### PR DESCRIPTION
We need to change port `11511` everywhere in our stack to support ROS2 as it is used in the topic discovery daemon.